### PR TITLE
Restore dep on brotlipy; align with CF.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,6 @@ requirements:
   host:
     - python >=3.6,<4.0
     - pip
-    - setuptools
-    - wheel
   run:
     - python >=3.6,<4.0
     # optional deps [secure]
@@ -29,14 +27,12 @@ requirements:
     # optional deps [socks]
     - pysocks >=1.5.6,<2.0,!=1.5.7
     # optional deps [brotli]
-    - brotli >=1.0.9
-
+    - brotlipy >=0.6.0
 
 test:
   imports:
     - urllib3
     - urllib3.contrib
-    - urllib3.contrib._securetransport
     - urllib3.packages
     - urllib3.packages.backports
     - urllib3.packages.ssl_match_hostname


### PR DESCRIPTION
This resolves the issue in [DSNC-3485](https://anaconda.atlassian.net/browse/DSNC-3485
) by restoring the dependency on `brotlipy` (not `brotli`).

Aligned the dependencies and tests with Conda-Forge's recipe.

Successful build on Concourse: https://concourse.build.corp.continuum.io/teams/main/pipelines/pyim_urllib3_1266