### PR TITLE
urllib3 1.26.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,12 @@
+{% set name = "urllib3" %}
 {% set version = "1.26.8" %}
 
 package:
-  name: urllib3
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/u/urllib3/urllib3-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/urllib3-{{ version }}.tar.gz
   sha256: 0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c
 
 build:
@@ -35,7 +36,6 @@ test:
     - urllib3.contrib
     - urllib3.packages
     - urllib3.packages.backports
-    - urllib3.packages.ssl_match_hostname
     - urllib3.util
   commands:
     - pip check
@@ -57,7 +57,7 @@ about:
     and dealing with HTTP redirects.
   doc_url: https://urllib3.readthedocs.io/
   dev_url: https://github.com/shazow/urllib3
-  doc_source_url: https://github.com/shazow/urllib3/tree/master/docs
+  doc_source_url: https://github.com/urllib3/urllib3/tree/{{ version }}/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python >=3.6,<4.0
+    - python <4.0
     - pip
   run:
-    - python >=3.6,<4.0
+    - python <4.0
     # optional deps [secure]
     - pyopenssl >=0.14
     - cryptography >=1.3.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.26.7" %}
+{% set version = "1.26.8" %}
 
 package:
   name: urllib3
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/u/urllib3/urllib3-{{ version }}.tar.gz
-  sha256: 4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece
+  sha256: 0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,6 +18,8 @@ requirements:
   host:
     - python <4.0
     - pip
+    - setuptools
+    - wheel
   run:
     - python <4.0
     # optional deps [secure]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ about:
     deflate encodings, HTTP and SOCKS proxy support, helpers for retrying requests
     and dealing with HTTP redirects.
   doc_url: https://urllib3.readthedocs.io/
-  dev_url: https://github.com/shazow/urllib3
+  dev_url: https://github.com/urllib3/urllib3
   doc_source_url: https://github.com/urllib3/urllib3/tree/{{ version }}/docs
 
 extra:


### PR DESCRIPTION
Update urllib3 to 1.26.8

Upstream changelog: https://github.com/urllib3/urllib3/blob/1.26.8/CHANGES.rst and https://github.com/urllib3/urllib3/releases
Bug tracker: https://github.com/urllib3/urllib3/issues
Upstream license: https://github.com/urllib3/urllib3/blob/1.26.8/LICENSE.txt
Upstream setup file: https://github.com/urllib3/urllib3/blob/1.26.8/setup.cfg and https://github.com/urllib3/urllib3/blob/1.26.8/setup.py

Actions:
1. Use jinja2 templates for package name and version
2. Fix python in `run` and `host`
3. Add `setuptools` and `wheel` in `host`
3. Update test/imports
4. Update dev, doc, and doc_source urls