### PR TITLE
urllib3 1.26.9

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "urllib3" %}
-{% set version = "1.26.8" %}
+{% set version = "1.26.9" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/urllib3-{{ version }}.tar.gz
-  sha256: 0e7c33d9a63e7ddfcb86780aac87befc2fbddf46c58dbb487e0855f7ceec283c
+  sha256: aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e
 
 build:
   number: 0


### PR DESCRIPTION
Update urllib3 to 1.26.9

Upstream changelog: https://github.com/urllib3/urllib3/blob/1.26.9/CHANGES.rst and https://github.com/urllib3/urllib3/releases
Bug tracker: https://github.com/urllib3/urllib3/issues
Upstream license: https://github.com/urllib3/urllib3/blob/1.26.9/LICENSE.txt
Upstream setup file: https://github.com/urllib3/urllib3/blob/1.26.9/setup.cfg and https://github.com/urllib3/urllib3/blob/1.26.9/setup.py

Actions:
1. Remove `noarch: python`