### PR TITLE
Updating version to 1.26.11. 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "urllib3" %}
-{% set version = "1.26.9" %}
+{% set version = "1.26.11" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/urllib3-{{ version }}.tar.gz
-  sha256: aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e
+  sha256: ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a
 
 build:
   number: 0
@@ -20,7 +20,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python <4.0
+    - python
     # optional deps [secure]
     - pyopenssl >=0.14
     - cryptography >=1.3.4


### PR DESCRIPTION
Nothing much has changed between 1.26.9 and 1.26.11.
- Updated version and hash
- Unpinned python

urllib3 setup config:
https://github.com/urllib3/urllib3/blob/1.26.11/setup.cfg

urllib3 github repo:
https://github.com/urllib3/urllib3/releases/tag/1.26.11