### PR TITLE
v1.26.16

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "urllib3" %}
-{% set version = "1.26.15" %}
+{% set version = "1.26.16" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305
+  sha256: 8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14
 
 
 build:
   number: 0
   skip: True  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:


### PR DESCRIPTION
# urllib3 v1.26.16
`setup.py`: https://github.com/urllib3/urllib3/blob/1.26.x/setup.py
release notes: https://github.com/urllib3/urllib3/releases/tag/1.26.16

## Notes
- This is a security patch version