### PR TITLE
update to 1.26.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "urllib3" %}
-{% set version = "1.26.16" %}
+{% set version = "1.26.18" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/urllib3-{{ version }}.tar.gz
+  sha256: f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0
 
 
 build:
@@ -31,9 +31,7 @@ requirements:
     # optional deps [socks]
     - pysocks >=1.5.6,<2.0,!=1.5.7
     # optional deps [brotli]
-    # issue with brotli and brotlicffi, so revert to brotlipy
-    # https://github.com/AnacondaRecipes/urllib3-feedstock/issues/2
-    - brotlipy >=0.6.0
+    - brotli-python >=1.0.9
 
 test:
   imports:


### PR DESCRIPTION
Changes:
- Update to 1.26.18
- switch from brotlipy to brotli-python (the former being deprecated)

https://github.com/urllib3/urllib3/tree/1.26.18