### PR TITLE
[PKG-4047] urllib3 2.1.0 fix

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_branch: 3.12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
@@ -22,10 +22,21 @@ requirements:
     - hatchling >=1.6.0,<2
   run:
     - python
+
+    # brotli-python and pysocks are optional dependencies but here for
+    # consistency because in previous versions (2.0.3 and 2.1.0) were
+    # specified as dependencies (as conda-forge does as well).
+    #
+    # optional deps [socks]
+    - pysocks >=1.5.6,<2.0,!=1.5.7
+    # optional deps [brotli]
+    - brotli-python >=1.0.9
   run_constrained:
     # based on https://github.com/urllib3/urllib3/issues/2680
     - requests >=2.26.0
     - selenium >=4.4.3
+    # optional deps [zstd]
+    - zstandard >=0.18.0
 
 test:
   imports:


### PR DESCRIPTION
urllib3 2.1.0 fix

**Destination channel:** defaults

### Links

- [PKG-4047]
- https://github.com/urllib3/urllib3/tree/2.1.0

### Explanation of changes:

 - `brotli-python` and `pysocks` are optional dependencies but added back here for consistency because in previous versions (2.0.3 and 2.0.7) were specified as dependencies (as conda-forge does as well).
 - see comment in the ticket for internal discussion



[PKG-4047]: https://anaconda.atlassian.net/browse/PKG-4047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ