### PR TITLE
Pkg 4505 urllib3-2.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,6 @@ source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19
 
-
 build:
   number: 0
   skip: True  # [py<38]
@@ -42,6 +41,9 @@ test:
     - urllib3.util
   commands:
     - pip check
+  # Test suite is being skipped due to transitive dependency on taskgroup
+  # Taskgroup is unstable as it only has pre-releases available
+    # - pytest -v --pyargs urlib3
   requires:
     - pip
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "urllib3" %}
-{% set version = "2.1.0" %}
+{% set version = "2.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54
+  sha256: d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19
 
 
 build:
-  number: 1
+  number: 0
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,8 +31,13 @@ requirements:
     # optional deps [brotli]
     - brotli-python >=1.0.9
   run_constrained:
-    - h2 >=4,<5
+    # based on https://github.com/urllib3/urllib3/issues/2680
+    - requests >=2.26.0
+    - selenium >=4.4.3
+    # optional deps [zstd]
     - zstandard >=0.18.0
+    # optional dep [h2]
+    - h2 >=4,<5
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,10 +32,7 @@ requirements:
     # optional deps [brotli]
     - brotli-python >=1.0.9
   run_constrained:
-    # based on https://github.com/urllib3/urllib3/issues/2680
-    - requests >=2.26.0
-    - selenium >=4.4.3
-    # optional deps [zstd]
+    - h2 >=4,<5
     - zstandard >=0.18.0
 
 test:


### PR DESCRIPTION
urllib3-2.2.1 :snowflake:

**Destination channel:** defaults

### Links

- [PKG-4505](https://anaconda.atlassian.net/browse/PKG-4505) 
- [Upstream repository](https://github.com/urllib3/urllib3/tree/2.2.1)
- [Upstream changelog/diff](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst)

### Explanation of changes:
- Leaving already listed optional dependencies for consistency
- Test suite is intentionally being skipped due to transitive dependency via `hypercorn` on `taskgroup`, which is unstable as it only has pre-releases available on PyPI


[PKG-4505]: https://anaconda.atlassian.net/browse/PKG-4505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ