### PR TITLE
update to 2.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "urllib3" %}
-{% set version = "2.2.1" %}
+{% set version = "2.2.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19
+  sha256: dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168
 
 build:
   number: 0


### PR DESCRIPTION
https://github.com/urllib3/urllib3/compare/2.2.1...2.2.2#diff-ff3c479edefad986d2fe6fe7ead575a46b086e3bbcf0ccc86d85efc4a4c63c79

Addresses https://nvd.nist.gov/vuln/detail/CVE-2024-37891